### PR TITLE
Ajout du winners et des custom stats dans le json

### DIFF
--- a/src/seahorse/__about__.py
+++ b/src/seahorse/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present U.N. Owen <void@some.where>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.7"
+__version__ = "1.1.6b2"

--- a/src/seahorse/__about__.py
+++ b/src/seahorse/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present U.N. Owen <void@some.where>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.6b1"
+__version__ = "1.1.7"

--- a/src/seahorse/game/custom_stat.py
+++ b/src/seahorse/game/custom_stat.py
@@ -1,0 +1,16 @@
+from typing import TypedDict
+
+
+class CustomStat(TypedDict):
+    """
+    A typed dictionary class representing a custom statistic format.
+
+    Attributes:
+        name (str): The statistic name.
+        value (object): The statistic value.
+        agent_id (int): The Player ID to which the statistic is attributed.
+    """
+
+    name: str
+    value: object
+    agent_id: int

--- a/src/seahorse/game/master.py
+++ b/src/seahorse/game/master.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from loguru import logger
 
+from seahorse.game.custom_stat import CustomStat
 from seahorse.game.game_state import GameState
 from seahorse.game.io_stream import EventMaster, EventSlave
 from seahorse.player.player import Player
@@ -259,7 +260,7 @@ class GameMaster:
             self.custom_stats = self.compute_custom_stats()
         return self.custom_stats
 
-    def compute_custom_stats(self) -> list[dict]:
+    def compute_custom_stats(self) -> list[CustomStat]:
         """
         Computes custom statistics for the game.
         It should be overridden by subclasses to provide specific statistics.
@@ -271,7 +272,7 @@ class GameMaster:
             ...
         ]
         Returns:
-            list[dict]: A list of dictionaries containing custom statistics.
+            list[CustomStat]: A list of dictionaries containing custom statistics.
         """
         return []
 

--- a/src/seahorse/game/master.py
+++ b/src/seahorse/game/master.py
@@ -151,6 +151,7 @@ class GameMaster:
                     logger.info(f"Winner - {player.get_name()}")
 
                 await self.emitter.sio.emit("done",json.dumps({
+                    "players": [{"id":player.get_id(), "name":player.get_name()} for player in self.current_game_state.get_players()],
                     "scores": self.get_scores(),
                     "custom_stats": self.get_custom_stats(),
                     "winner_id": next(iter([player.get_id() for player in self.current_game_state.get_players() if 
@@ -177,6 +178,7 @@ class GameMaster:
             logger.info(f"Winner - {player.get_name()}")
 
         await self.emitter.sio.emit("done",json.dumps({
+            "players": [{"id":player.get_id(), "name":player.get_name()} for player in self.current_game_state.get_players()],
             "scores": self.get_scores(),
             "custom_stats": self.get_custom_stats(),
             "winner_id": next(iter([player.get_id() for player in self.get_winner()])),

--- a/src/seahorse/game/master.py
+++ b/src/seahorse/game/master.py
@@ -251,10 +251,10 @@ class GameMaster:
         """
         return self.current_game_state.get_scores()
 
-    def get_custom_stats(self) -> list[dict]:
+    def get_custom_stats(self) -> list[CustomStat]:
         """
         Returns:
-            list[dict]: The custom statistics of the game.
+            list[CustomState]: The custom statistics of the game.
         """
         if not hasattr(self, "custom_stats"):
             self.custom_stats = self.compute_custom_stats()

--- a/src/seahorse/game/master.py
+++ b/src/seahorse/game/master.py
@@ -234,7 +234,7 @@ class GameMaster:
                 self.winner = [player for player in self.current_game_state.get_players() if player.get_id() != looser_id]
             else:
                 self.winner = self.compute_winner()
-        
+
         return self.winner
 
     def get_scores(self) -> dict[int, float]:
@@ -243,7 +243,7 @@ class GameMaster:
             Dict: The scores of the current state.
         """
         return self.current_game_state.get_scores()
-    
+
     def get_custom_stats(self) -> list[dict]:
         """
         Returns:
@@ -266,7 +266,6 @@ class GameMaster:
         ]
         Returns:
             list[dict]: A list of dictionaries containing custom statistics.
-        
         """
         return []
 

--- a/src/seahorse/utils/recorders.py
+++ b/src/seahorse/utils/recorders.py
@@ -1,5 +1,6 @@
 import builtins
 import json
+import os
 import random
 import time
 
@@ -7,30 +8,51 @@ from seahorse.game.io_stream import EventSlave
 
 
 class StateRecorder(EventSlave):
-    """ An event slave that records everything state emitted by the master in a json file
+    """
+    An event slave that records everything state emitted by the master in a json file
     """
 
     def __init__(self) -> None:
         super().__init__()
-        self.identifier = "__REC__"+str(int(time.time()*1000000-random.randint(1,1000000)))
+        self.identifier = "__REC__"+str(int(time.time()*1000000-random.randint(1,1000000)))  # noqa: S311
         self.id = builtins.id(self)
         self.wrapped_id = self.id
         self.sid = None
 
         self.activate(self.identifier)
-        self.recorded_content = {"steps" : [], "final_summary" : None}
+
+        self.filepath = self.identifier + ".json"
+         # Initialize file if needed
+        if not os.path.exists(self.filepath) or os.path.getsize(self.filepath) == 0:
+            with open(self.filepath, "w") as f:
+                json.dump({"steps": [], "final_summary": None}, f)
 
         @self.sio.on("play")
         def record_play(data):
-            self.recorded_content["steps"].append(json.loads(data))
+            step = json.loads(data)
+            self.append_step(step)
 
         @self.sio.on("done")
         def record_done(data):
-            self.recorded_content["final_summary"] = json.loads(data)
+            final_summary = json.loads(data)
+            self.update_final_summary(final_summary)
 
         @self.sio.event()
         def disconnect():
-            with open(self.identifier+".json","w+") as f:
-                f.write(json.dumps(self.recorded_content))
+            pass
 
+    def append_step(self, step):
+        with open(self.filepath, "r+") as f:
+            content = json.load(f)
+            content["steps"].append(step)
+            f.seek(0)
+            json.dump(content, f)
+            f.truncate()
 
+    def update_final_summary(self, final_summary):
+        with open(self.filepath, "r+") as f:
+            content = json.load(f)
+            content["final_summary"] = final_summary
+            f.seek(0)
+            json.dump(content, f)
+            f.truncate()

--- a/src/seahorse/utils/recorders.py
+++ b/src/seahorse/utils/recorders.py
@@ -14,7 +14,7 @@ class StateRecorder(EventSlave):
 
     def __init__(self) -> None:
         super().__init__()
-        self.identifier = "__REC__"+str(int(time.time()*1000000-random.randint(1,1000000)))  # noqa: S311
+        self.identifier = "__REC__"+str(int(time.time()*1000000-random.randint(1,1000000)))
         self.id = builtins.id(self)
         self.wrapped_id = self.id
         self.sid = None

--- a/src/seahorse/utils/recorders.py
+++ b/src/seahorse/utils/recorders.py
@@ -18,11 +18,15 @@ class StateRecorder(EventSlave):
         self.sid = None
 
         self.activate(self.identifier)
-        self.recorded_content = []
+        self.recorded_content = {"steps" : [], "final_summary" : None}
 
         @self.sio.on("play")
         def record_play(data):
-            self.recorded_content.append(json.loads(data))
+            self.recorded_content["steps"].append(json.loads(data))
+
+        @self.sio.on("done")
+        def record_done(data):
+            self.recorded_content["final_summary"] = json.loads(data)
 
         @self.sio.event()
         def disconnect():


### PR DESCRIPTION
J'ai mis les infos du winner / scores et custom stats directement dans le json. 
Maintenant le json est un dictionnaire avec 2 clé : steps : [...] (ou il y a les steps comme avant) et final_summary: {} qui est a None pendant toute la partie et qui au dernier tour devient un dict avec winner_id, scores, et custom_stats.
plus besoin de retrouver le winner  / les customs stats dans l'arena.